### PR TITLE
Non-isotropic length scales for graph-based Gaussian processes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   # Our tests may contain a number of stochastic elements. Setting a seed will make sure they are
   # not flaky (but also hide potential issues).
   SEED: "0"
-  cmdstanVersion: "2.36.0-rc1"
+  cmdstanVersion: "2.36.0-rc2"
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   # Our tests may contain a number of stochastic elements. Setting a seed will make sure they are
   # not flaky (but also hide potential issues).
   SEED: "0"
-  cmdstanVersion: "2.36.0-rc2"
+  cmdstanVersion: "2.36.0"
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   # Our tests may contain a number of stochastic elements. Setting a seed will make sure they are
   # not flaky (but also hide potential issues).
   SEED: "0"
-  cmdstanVersion: "2.34.1"
+  cmdstanVersion: "2.36.0-rc1"
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
   # Our tests may contain a number of stochastic elements. Setting a seed will make sure they are
   # not flaky (but also hide potential issues).
   SEED: "0"
-  cmdstanVersion: "2.31.0"
+  cmdstanVersion: "2.34.1"
 
 jobs:
   build:

--- a/stan/docs/interface/fft.rst
+++ b/stan/docs/interface/fft.rst
@@ -9,7 +9,7 @@ Utility Functions
 The following functions, and their two-dimensional analogues, primarily exist as utility functions but may be useful for more complex models.
 
 - :stan:func:`gp_rfft` transforms Gaussian process realizations to the Fourier domain and scales the coefficients such that they are white noise under the Gaussian process prior.
-- :stan:func:`gp_rfft_log_abs_det_jacobian` evaluates the log absolute determinant of the Jacobian associated with the transformations :stan:func:`gp_rfft`.
+- :stan:func:`gp_rfft_log_abs_det_jac` evaluates the log absolute determinant of the Jacobian associated with the transformations :stan:func:`gp_rfft`.
 
 Together, these two functions are used by :stan:func:`gp_rfft_lpdf` to evaluate the likelihood.
 

--- a/stan/gptools/stan/__init__.py
+++ b/stan/gptools/stan/__init__.py
@@ -9,6 +9,17 @@ def get_include() -> str:
     """
     Get the include directory for the library.
     """
+    version = cmdstanpy.cmdstan_version()
+    if version and version < (2, 36):  # pragma: no cover
+        logging.warning(
+            "cmdstan<2.36.0 had a bug in the evaluation of Matern 3/2 kernels "
+            "with different length scales for different dimensions; see "
+            "https://github.com/stan-dev/math/pull/3084 for details. Your "
+            "model may yield unexpected results or crash if you use "
+            "nearest-neighbor Gaussian processes with Matern 3/2 kernels. Your "
+            "cmdstan version is %d.%d; consider upgrading.",
+            *version,
+        )
     return os.path.dirname(__file__)
 
 

--- a/stan/gptools/stan/gptools/fft1.stan
+++ b/stan/gptools/stan/gptools/fft1.stan
@@ -75,7 +75,7 @@ Evaluate the log absolute determinant of the Jacobian associated with
 :param n: Size of the real signal. Necessary because the size cannot be inferred from :code:`rfft`.
 :returns: Log absolute determinant of the Jacobian.
 */
-real gp_rfft_log_abs_det_jacobian(vector cov_rfft, int n) {
+real gp_rfft_log_abs_det_jac(vector cov_rfft, int n) {
     vector[n %/% 2 + 1] rfft_scale = gp_evaluate_rfft_scale(cov_rfft, n);
     return - sum(log(rfft_scale[1:n %/% 2 + 1])) -sum(log(rfft_scale[2:(n + 1) %/% 2]))
         - log(2) * ((n - 1) %/% 2) + n * log(n) / 2;
@@ -94,7 +94,7 @@ real gp_rfft_lpdf(vector y, vector loc, vector cov_rfft) {
     int n = size(y);
     int nrfft = n %/% 2 + 1;
     vector[n] z = gp_rfft(y, loc, cov_rfft);
-    return std_normal_lpdf(z) + gp_rfft_log_abs_det_jacobian(cov_rfft, n);
+    return std_normal_lpdf(z) + gp_rfft_log_abs_det_jac(cov_rfft, n);
 }
 
 

--- a/stan/gptools/stan/gptools/fft2.stan
+++ b/stan/gptools/stan/gptools/fft2.stan
@@ -140,7 +140,7 @@ Evaluate the log absolute determinant of the Jacobian associated with
     Fourier transform :code:`cov_rfft2`).
 :returns: Log absolute determinant of the Jacobian.
 */
-real gp_rfft2_log_abs_det_jacobian(matrix cov_rfft2, int width) {
+real gp_rfft2_log_abs_det_jac(matrix cov_rfft2, int width) {
     int height = rows(cov_rfft2);
     int n = width * height;
     int fftwidth = width %/% 2 + 1;
@@ -185,7 +185,7 @@ Evaluate the log probability of a two-dimensional Gaussian process realization i
 */
 real gp_rfft2_lpdf(matrix y, matrix loc, matrix cov_rfft2) {
     return std_normal_lpdf(to_vector(gp_rfft2(y, loc, cov_rfft2)))
-        + gp_rfft2_log_abs_det_jacobian(cov_rfft2, cols(y));
+        + gp_rfft2_log_abs_det_jac(cov_rfft2, cols(y));
 }
 
 

--- a/stan/gptools/stan/gptools/graph.stan
+++ b/stan/gptools/stan/gptools/graph.stan
@@ -49,6 +49,12 @@ vector gp_graph_conditional_loc_scale(
     int node, array [] int predecessors, real epsilon
 ) {
     int k = size(predecessors);
+
+    // If there are no predecessors, we simply use the marginal distribution.
+    if (k == 0) {
+        return [0, sqrt(sigma ^ 2 + epsilon)]';
+    }
+
     matrix[1, k] cov12;
     matrix[k, k] cov22;
     if (kernel == 0) {

--- a/stan/gptools/stan/gptools/graph.stan
+++ b/stan/gptools/stan/gptools/graph.stan
@@ -45,7 +45,7 @@ Evaluate the location and scale for a node given its predecessors, assuming zero
 :returns: Location and scale parameters for the distribution of the node given its predecessors.
 */
 vector gp_graph_conditional_loc_scale(
-    vector y, array[] vector x, int kernel, real sigma, real length_scale,
+    vector y, array[] vector x, int kernel, real sigma, array [] real length_scale,
     int node, array [] int predecessors, real epsilon
 ) {
     int k = size(predecessors);
@@ -86,7 +86,8 @@ Evaluate the log probability of a graph Gaussian process.
 :returns: Log probability of the graph Gaussian process.
 */
 real gp_graph_lpdf(vector y, vector loc, array [] vector x, int kernel, real sigma,
-                   real length_scale, array [,] int edges, array[] int degrees, real epsilon) {
+    array [] real length_scale, array [,] int edges, array[] int degrees, real epsilon
+) {
     real lpdf = 0;
     int offset_ = 1;
     vector[size(y)] z = y - loc;
@@ -97,6 +98,39 @@ real gp_graph_lpdf(vector y, vector loc, array [] vector x, int kernel, real sig
         offset_ += degrees[i];
     }
     return lpdf;
+}
+
+
+/**
+Evaluate the log probability of a graph Gaussian process.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param kernel: Kernel to use (0 for squared exponential, 1 for Matern 3/2, 2 for Matern 5/2).
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_lpdf(
+    vector y,
+    vector loc,
+    array [] vector x,
+    int kernel,
+    real sigma,
+    real length_scale,
+    array [,] int edges,
+    array[] int degrees,
+    real epsilon
+) {
+    int p = size(x[1]);
+    return gp_graph_lpdf(y | loc, x, kernel, sigma, rep_array(length_scale, p), edges, degrees, epsilon);
 }
 
 
@@ -123,6 +157,28 @@ real gp_graph_lpdf(vector y, vector loc, array [] vector x, int kernel, real sig
 
 
 /**
+Evaluate the log probability of a graph Gaussian process.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param kernel: Kernel to use (0 for squared exponential, 1 for Matern 3/2, 2 for Matern 5/2).
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_lpdf(vector y, vector loc, array [] vector x, int kernel, real sigma,
+                   array [] real length_scale, array [,] int edges) {
+    return gp_graph_lpdf(y | loc, x, kernel, sigma, length_scale, edges,
+                         out_degrees(size(y), edges), 1e-12);
+}
+
+
+/**
 Transform white noise to a sample from a graph Gaussian process
 
 :param z: White noise for each node.
@@ -130,7 +186,7 @@ Transform white noise to a sample from a graph Gaussian process
 :param x: Position of each node.
 :param kernel: Kernel to use (0 for squared exponential, 1 for Matern 3/2, 2 for Matern 5/2).
 :param sigma: Marginal scale of the kernel.
-:param length_scale: Correlation length of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
 :param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
     as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
     comprises parents of children in the second row. The first row can have arbitrary order, but the
@@ -140,7 +196,8 @@ Transform white noise to a sample from a graph Gaussian process
 :returns: Sample from the Graph gaussian process.
 */
 vector gp_inv_graph(vector z, vector loc, array [] vector x, int kernel, real sigma,
-                    real length_scale, array [,] int edges, array [] int degrees, real epsilon) {
+    array [] real length_scale, array [,] int edges, array [] int degrees, real epsilon
+) {
     vector[size(z)] y;
     int offset_ = 1;
     for (i in 1:size(x)) {
@@ -166,11 +223,59 @@ Transform white noise to a sample from a graph Gaussian process
     as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
     comprises parents of children in the second row. The first row can have arbitrary order, but the
     second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph(vector z, vector loc, array [] vector x, int kernel, real sigma,
+                    real length_scale, array [,] int edges, array [] int degrees, real epsilon
+) {
+    int p = size(x[1]);
+    return gp_inv_graph(z, loc, x, kernel, sigma, rep_array(length_scale, p), edges, degrees, epsilon);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param kernel: Kernel to use (0 for squared exponential, 1 for Matern 3/2, 2 for Matern 5/2).
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph(vector z, vector loc, array [] vector x, int kernel, real sigma,
+                    array [] real length_scale, array [,] int edges) {
+    return gp_inv_graph(z, loc, x, kernel, sigma, length_scale, edges,
+                                  out_degrees(size(z), edges), 1e-12);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param kernel: Kernel to use (0 for squared exponential, 1 for Matern 3/2, 2 for Matern 5/2).
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
 :returns: Sample from the Graph gaussian process.
 */
 vector gp_inv_graph(vector z, vector loc, array [] vector x, int kernel, real sigma,
                     real length_scale, array [,] int edges) {
-    return gp_inv_graph(z, loc, x, kernel, sigma, length_scale, edges,
+    int p = size(x[1]);
+    return gp_inv_graph(z, loc, x, kernel, sigma, rep_array(length_scale, p), edges,
                                   out_degrees(size(z), edges), 1e-12);
 }
 
@@ -195,6 +300,29 @@ Evaluate the log probability of a graph Gaussian with squared exponential kernel
 real gp_graph_exp_quad_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
                                 real length_scale, array [,] int edges, array[] int degrees,
                                 real epsilon) {
+    return gp_graph_lpdf(y | loc, x, 0, sigma, length_scale, edges, degrees, epsilon);
+}
+
+
+/**
+Evaluate the log probability of a graph Gaussian with squared exponential kernel.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_exp_quad_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
+                                array [] real length_scale, array [,] int edges, array[] int degrees, real epsilon
+) {
     return gp_graph_lpdf(y | loc, x, 0, sigma, length_scale, edges, degrees, epsilon);
 }
 
@@ -238,6 +366,32 @@ Transform white noise to a sample from a graph Gaussian process with squared exp
 vector gp_inv_graph_exp_quad_cov(vector z, vector loc, array [] vector x, real sigma,
                                  real length_scale, array [,] int edges, array [] int degrees,
                                  real epsilon) {
+    int p = size(x[1]);
+    return gp_inv_graph(z, loc, x, 0, sigma, rep_array(length_scale, p), edges, degrees, epsilon);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with squared
+exponential kernel and different length scales along each feature dimension.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation lengths of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic
+    graph. Edges are stored as a matrix with shape :code:`(2, m)`, where
+    :code:`m` is the number of edges. The first row comprises parents of
+    children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_exp_quad_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges, array [] int degrees, real epsilon
+) {
     return gp_inv_graph(z, loc, x, 0, sigma, length_scale, edges, degrees, epsilon);
 }
 
@@ -258,6 +412,26 @@ Transform white noise to a sample from a graph Gaussian process with squared exp
 */
 vector gp_inv_graph_exp_quad_cov(vector z, vector loc, array [] vector x, real sigma,
                                  real length_scale, array [,] int edges) {
+    return gp_inv_graph(z, loc, x, 0, sigma, length_scale, edges);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with squared exponential kernel.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_exp_quad_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges) {
     return gp_inv_graph(z, loc, x, 0, sigma, length_scale, edges);
 }
 
@@ -308,6 +482,49 @@ real gp_graph_matern32_cov_lpdf(vector y, vector loc, array [] vector x, real si
 
 
 /**
+Evaluate the log probability of a graph Gaussian with Matern 3 / 2 kernel.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_matern32_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
+                                array [] real length_scale, array [,] int edges, array[] int degrees,
+                                real epsilon) {
+    return gp_graph_lpdf(y | loc, x, 1, sigma, length_scale, edges, degrees, epsilon);
+}
+
+
+/**
+Evaluate the log probability of a graph Gaussian with Matern 3 / 2 kernel.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_matern32_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
+                                array [] real length_scale, array [,] int edges) {
+    return gp_graph_lpdf(y | loc, x, 1, sigma, length_scale, edges);
+}
+
+
+/**
 Transform white noise to a sample from a graph Gaussian process with Matern 3 / 2 kernel.
 
 :param z: White noise for each node.
@@ -346,6 +563,49 @@ Transform white noise to a sample from a graph Gaussian process with Matern 3 / 
 */
 vector gp_inv_graph_matern32_cov(vector z, vector loc, array [] vector x, real sigma,
                                  real length_scale, array [,] int edges) {
+    return gp_inv_graph(z, loc, x, 1, sigma, length_scale, edges);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with Matern 3 / 2 kernel.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_matern32_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges, array [] int degrees,
+                                 real epsilon) {
+    return gp_inv_graph(z, loc, x, 1, sigma, length_scale, edges, degrees, epsilon);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with Matern 3 / 2 kernel.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_matern32_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges) {
     return gp_inv_graph(z, loc, x, 1, sigma, length_scale, edges);
 }
 
@@ -396,6 +656,49 @@ real gp_graph_matern52_cov_lpdf(vector y, vector loc, array [] vector x, real si
 
 
 /**
+Evaluate the log probability of a graph Gaussian with Matern 5 / 2 kernel.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_matern52_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
+                                array [] real length_scale, array [,] int edges, array[] int degrees,
+                                real epsilon) {
+    return gp_graph_lpdf(y | loc, x, 2, sigma, length_scale, edges, degrees, epsilon);
+}
+
+
+/**
+Evaluate the log probability of a graph Gaussian with Matern 5 / 2 kernel.
+
+:param y: State of each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Log probability of the graph Gaussian process.
+*/
+real gp_graph_matern52_cov_lpdf(vector y, vector loc, array [] vector x, real sigma,
+                                array [] real length_scale, array [,] int edges) {
+    return gp_graph_lpdf(y | loc, x, 2, sigma, length_scale, edges);
+}
+
+
+/**
 Transform white noise to a sample from a graph Gaussian process with Matern 5 / 2 kernel.
 
 :param z: White noise for each node.
@@ -434,5 +737,48 @@ Transform white noise to a sample from a graph Gaussian process with Matern 5 / 
 */
 vector gp_inv_graph_matern52_cov(vector z, vector loc, array [] vector x, real sigma,
                                  real length_scale, array [,] int edges) {
+    return gp_inv_graph(z, loc, x, 2, sigma, length_scale, edges);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with Matern 5 / 2 kernel.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:param degrees: Out-degree of each node.
+:param epsilon: Nugget variance for numerical stability.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_matern52_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges, array [] int degrees,
+                                 real epsilon) {
+    return gp_inv_graph(z, loc, x, 2, sigma, length_scale, edges, degrees, epsilon);
+}
+
+
+/**
+Transform white noise to a sample from a graph Gaussian process with Matern 5 / 2 kernel.
+
+:param z: White noise for each node.
+:param loc: Mean of each node.
+:param x: Position of each node.
+:param sigma: Marginal scale of the kernel.
+:param length_scale: Correlation length of the kernel for each dimension.
+:param edges: Directed edges between nodes constituting a directed acyclic graph. Edges are stored
+    as a matrix with shape :code:`(2, m)`, where :code:`m` is the number of edges. The first row
+    comprises parents of children in the second row. The first row can have arbitrary order, but the
+    second row must be sorted.
+:returns: Sample from the Graph gaussian process.
+*/
+vector gp_inv_graph_matern52_cov(vector z, vector loc, array [] vector x, real sigma,
+                                 array [] real length_scale, array [,] int edges) {
     return gp_inv_graph(z, loc, x, 2, sigma, length_scale, edges);
 }

--- a/stan/gptools/stan/gptools/graph.stan
+++ b/stan/gptools/stan/gptools/graph.stan
@@ -44,9 +44,10 @@ Evaluate the location and scale for a node given its predecessors, assuming zero
 :param epsilon: Nugget variance for numerical stability.
 :returns: Location and scale parameters for the distribution of the node given its predecessors.
 */
-vector gp_graph_conditional_loc_scale(vector y, array[] vector x, int kernel, real sigma,
-                                      real length_scale, int node, array [] int predecessors,
-                                      real epsilon) {
+vector gp_graph_conditional_loc_scale(
+    vector y, array[] vector x, int kernel, real sigma, real length_scale,
+    int node, array [] int predecessors, real epsilon
+) {
     int k = size(predecessors);
     matrix[1, k] cov12;
     matrix[k, k] cov22;

--- a/stan/tests/test_stan_functions.py
+++ b/stan/tests/test_stan_functions.py
@@ -73,7 +73,8 @@ def assert_stan_function_allclose(
         raise RuntimeError(f"failed to compile model for {stan_function} at {line_info}") from ex
 
     try:
-        fit = model.sample(arg_values, fixed_param=True, iter_sampling=1, iter_warmup=1, sig_figs=9, chains=1)
+        fit = model.sample(arg_values, fixed_param=True, iter_sampling=1, iter_warmup=1, sig_figs=9,
+                           chains=1)
         success, = fit.stan_variable("success")
         if not success or np.isnan(success):
             console = pathlib.Path(fit.runset.stdout_files[0]).read_text()

--- a/stan/tests/test_stan_functions.py
+++ b/stan/tests/test_stan_functions.py
@@ -2,7 +2,6 @@ from gptools.stan import compile_model
 from gptools.util import coordgrid, fft, kernels
 import hashlib
 import inspect
-import itertools as it
 import numpy as np
 import pathlib
 import pytest

--- a/stan/tests/test_stan_functions.py
+++ b/stan/tests/test_stan_functions.py
@@ -76,7 +76,8 @@ def assert_stan_function_allclose(
         fit = model.sample(arg_values, fixed_param=True, iter_sampling=1, iter_warmup=1, sig_figs=9, chains=1)
         success, = fit.stan_variable("success")
         if not success or np.isnan(success):
-            raise RuntimeError("failed to sample from model")
+            console = pathlib.Path(fit.runset.stdout_files[0]).read_text()
+            raise RuntimeError(f"failed to sample from model: \n{console}")
     except Exception as ex:
         if raises:
             return

--- a/torch/gptools/torch/fft/fft1.py
+++ b/torch/gptools/torch/fft/fft1.py
@@ -1,4 +1,4 @@
-from gptools.util.fft import transform_rfft, transform_irfft, evaluate_rfft_log_abs_det_jacobian
+from gptools.util.fft import transform_rfft, transform_irfft, evaluate_rfft_log_abs_det_jac
 from gptools.util.fft.fft1 import _get_rfft_scale
 import torch as th
 from torch.distributions import constraints
@@ -44,7 +44,7 @@ class FourierGaussianProcess1DTransform(th.distributions.Transform):
         return transform_irfft(y, self.loc, rfft_scale=self.rfft_scale)
 
     def log_abs_det_jacobian(self, x: th.Tensor, y: th.Tensor) -> th.Tensor:
-        return evaluate_rfft_log_abs_det_jacobian(x.shape[-1], rfft_scale=self.rfft_scale)
+        return evaluate_rfft_log_abs_det_jac(x.shape[-1], rfft_scale=self.rfft_scale)
 
 
 class FourierGaussianProcess1D(th.distributions.TransformedDistribution):

--- a/torch/gptools/torch/fft/fft2.py
+++ b/torch/gptools/torch/fft/fft2.py
@@ -1,4 +1,4 @@
-from gptools.util.fft import transform_rfft2, transform_irfft2, evaluate_rfft2_log_abs_det_jacobian
+from gptools.util.fft import transform_rfft2, transform_irfft2, evaluate_rfft2_log_abs_det_jac
 from gptools.util.fft.fft2 import _get_rfft2_scale
 import torch as th
 from .. import OptionalTensor
@@ -45,7 +45,7 @@ class FourierGaussianProcess2DTransform(th.distributions.Transform):
         return transform_irfft2(y, self.loc, rfft2_scale=self.rfft2_scale)
 
     def log_abs_det_jacobian(self, x: th.Tensor, y: th.Tensor) -> th.Tensor:
-        return evaluate_rfft2_log_abs_det_jacobian(x.shape[-1], rfft2_scale=self.rfft2_scale)
+        return evaluate_rfft2_log_abs_det_jac(x.shape[-1], rfft2_scale=self.rfft2_scale)
 
 
 class FourierGaussianProcess2D(th.distributions.TransformedDistribution):

--- a/util/gptools/util/fft/__init__.py
+++ b/util/gptools/util/fft/__init__.py
@@ -1,6 +1,6 @@
-from .fft1 import evaluate_log_prob_rfft, evaluate_rfft_log_abs_det_jacobian, expand_rfft, \
+from .fft1 import evaluate_log_prob_rfft, evaluate_rfft_log_abs_det_jac, expand_rfft, \
     transform_irfft, transform_rfft
-from .fft2 import evaluate_log_prob_rfft2, evaluate_rfft2_log_abs_det_jacobian, transform_irfft2, \
+from .fft2 import evaluate_log_prob_rfft2, evaluate_rfft2_log_abs_det_jac, transform_irfft2, \
     transform_rfft2
 from .util import log_prob_stdnorm
 
@@ -8,8 +8,8 @@ from .util import log_prob_stdnorm
 __all__ = [
     "evaluate_log_prob_rfft",
     "evaluate_log_prob_rfft2",
-    "evaluate_rfft_log_abs_det_jacobian",
-    "evaluate_rfft2_log_abs_det_jacobian",
+    "evaluate_rfft_log_abs_det_jac",
+    "evaluate_rfft2_log_abs_det_jac",
     "expand_rfft",
     "log_prob_stdnorm",
     "transform_irfft",

--- a/util/gptools/util/fft/fft1.py
+++ b/util/gptools/util/fft/fft1.py
@@ -185,12 +185,12 @@ def evaluate_log_prob_rfft(y: ArrayOrTensor, loc: ArrayOrTensor, *,
     rfft_scale = _get_rfft_scale(cov_rfft, cov, rfft_scale, y.shape[-1])
     rfft = transform_rfft(y, loc, rfft_scale=rfft_scale)
     return log_prob_stdnorm(rfft).sum(axis=-1) \
-        + evaluate_rfft_log_abs_det_jacobian(y.shape[-1], rfft_scale=rfft_scale)
+        + evaluate_rfft_log_abs_det_jac(y.shape[-1], rfft_scale=rfft_scale)
 
 
-def evaluate_rfft_log_abs_det_jacobian(size: int, *, cov_rfft: OptionalArrayOrTensor = None,
-                                       cov: OptionalArrayOrTensor = None,
-                                       rfft_scale: OptionalArrayOrTensor = None) -> ArrayOrTensor:
+def evaluate_rfft_log_abs_det_jac(size: int, *, cov_rfft: OptionalArrayOrTensor = None,
+                                  cov: OptionalArrayOrTensor = None,
+                                  rfft_scale: OptionalArrayOrTensor = None) -> ArrayOrTensor:
     """
     Evaluate the log absolute determinant of the Jacobian associated with :func:`transform_rfft`.
 
@@ -202,7 +202,7 @@ def evaluate_rfft_log_abs_det_jacobian(size: int, *, cov_rfft: OptionalArrayOrTe
             :code:`(..., size // 2 + 1)`.
 
     Returns:
-        log_abs_det_jacobian: Log absolute determinant of the Jacobian.
+        log_abs_det_jac: Log absolute determinant of the Jacobian.
     """
     imagidx = (size + 1) // 2
     rfft_scale = _get_rfft_scale(cov_rfft, cov, rfft_scale, size)

--- a/util/gptools/util/fft/fft2.py
+++ b/util/gptools/util/fft/fft2.py
@@ -178,9 +178,9 @@ def transform_rfft2(y: ArrayOrTensor, loc: ArrayOrTensor, *,
     return unpack_rfft2(dispatch[y].fft.rfft2(y - loc) / rfft2_scale, y.shape)
 
 
-def evaluate_rfft2_log_abs_det_jacobian(width: int, *, cov_rfft2: OptionalArrayOrTensor = None,
-                                        cov: OptionalArrayOrTensor = None,
-                                        rfft2_scale: OptionalArrayOrTensor = None) -> ArrayOrTensor:
+def evaluate_rfft2_log_abs_det_jac(width: int, *, cov_rfft2: OptionalArrayOrTensor = None,
+                                   cov: OptionalArrayOrTensor = None,
+                                   rfft2_scale: OptionalArrayOrTensor = None) -> ArrayOrTensor:
     """
     Evaluate the log absolute determinant of the Jacobian associated with :func:`transform_rfft2`.
 
@@ -194,7 +194,7 @@ def evaluate_rfft2_log_abs_det_jacobian(width: int, *, cov_rfft2: OptionalArrayO
             :code:`(..., height, width // 2 + 1)`.
 
     Returns:
-        log_abs_det_jacobian: Log absolute determinant of the Jacobian.
+        log_abs_det_jac: Log absolute determinant of the Jacobian.
     """
     rfft2_scale = _get_rfft2_scale(cov_rfft2, cov, rfft2_scale, width)
     height = rfft2_scale.shape[-2]
@@ -249,4 +249,4 @@ def evaluate_log_prob_rfft2(y: ArrayOrTensor, loc: ArrayOrTensor, *,
     rfft2_scale = _get_rfft2_scale(cov_rfft2, cov, rfft2_scale, y.shape[-1])
     rfft2 = transform_rfft2(y, loc, rfft2_scale=rfft2_scale)
     return log_prob_stdnorm(rfft2).sum(axis=(-2, -1)) \
-        + evaluate_rfft2_log_abs_det_jacobian(y.shape[-1], rfft2_scale=rfft2_scale)
+        + evaluate_rfft2_log_abs_det_jac(y.shape[-1], rfft2_scale=rfft2_scale)


### PR DESCRIPTION
This PR allows graph-based Gaussian processes to have different length scales along different dimensions of the covariate space.