### PR TITLE
Explicit error message for deprecated function.

### DIFF
--- a/stan/gptools/stan/gptools/fft1.stan
+++ b/stan/gptools/stan/gptools/fft1.stan
@@ -80,6 +80,9 @@ real gp_rfft_log_abs_det_jac(vector cov_rfft, int n) {
     return - sum(log(rfft_scale[1:n %/% 2 + 1])) -sum(log(rfft_scale[2:(n + 1) %/% 2]))
         - log(2) * ((n - 1) %/% 2) + n * log(n) / 2;
 }
+real gp_rfft_log_abs_det_jacobian(vector cov_rfft, int n) {
+    reject("`gp_rfft_log_abs_det_jacobian` has been renamed to `gp_rfft_log_abs_det_jac` to comply with upcoming changes (see https://github.com/stan-dev/stanc3/issues/1470 for details).");
+}
 
 
 /**

--- a/stan/gptools/stan/gptools/fft2.stan
+++ b/stan/gptools/stan/gptools/fft2.stan
@@ -171,6 +171,9 @@ real gp_rfft2_log_abs_det_jac(matrix cov_rfft2, int width) {
     ladj += - log2() * nterms + n * log(n) / 2;
     return ladj;
 }
+real gp_rfft2_log_abs_det_jacobian(matrix cov_rfft2, int width) {
+    reject("`gp_rfft2_log_abs_det_jacobian` has been renamed to `gp_rfft2_log_abs_det_jac` to comply with upcoming changes (see https://github.com/stan-dev/stanc3/issues/1470 for details).");
+}
 
 
 /**


### PR DESCRIPTION
Functions ending with `_jacobian` will likely fail in future versions of Stan (cf. stan-dev/stanc3#1470). This PR adds an explicit error message for the renaming of `_jacobian -> _jac` in #23.